### PR TITLE
Merge Experimental Branch

### DIFF
--- a/lua/autorun/server/sv_autorun.lua
+++ b/lua/autorun/server/sv_autorun.lua
@@ -4,6 +4,7 @@ if SERVER then
     approvedNominations = {}
     usableMaps = {}
     installedMaps = {}
+    mapData = {}
     votedPlayers = {}
     mapchangeSent = false
     

--- a/lua/autorun/server/sv_nominations.lua
+++ b/lua/autorun/server/sv_nominations.lua
@@ -26,7 +26,9 @@ function checkPlayerNomination(ply,text,team)
             if tableContains(usableMaps,map) then  
                 -- if map is not duplicate
                 if not tableContains(approvedNominations, map) then 
-                    return true
+                    if determineMapRatioLegal(map) then
+                        return true
+                    end
                 end
             end
             return false
@@ -49,6 +51,12 @@ function checkPlayerNomination(ply,text,team)
                 if tableContains(approvedNominations,text) then
                     timer.Create("invalidMapResponse", (1/30), 1, function()
                         ply:PrintMessage(HUD_PRINTTALK, text .. " was already nominated!")
+                    end)
+                end
+                local err,msg = determineMapRatioLegal(text)
+                if not err then 
+                    timer.Create("invalidMapResponse", (1/30), 1, function()
+                        ply:PrintMessage(HUD_PRINTTALK, text .. " was not nominated because " .. msg)
                     end)
                 end
             end

--- a/lua/autorun/server/sv_setup.lua
+++ b/lua/autorun/server/sv_setup.lua
@@ -4,9 +4,9 @@ RunConsoleCommand("mapcyclefile", "data/rcmapvote/nextmap.txt")
 CreateConVar("rcmv_whitelist", 0, { FCVAR_ARCHIVE, FCVAR_SERVER_CAN_EXECUTE }, "Decides if maplist.txt is used as a whitelist or a blacklist.")
 CreateConVar("rcmv_votingduration", "120", { FCVAR_ARCHIVE, FCVAR_SERVER_CAN_EXECUTE }) -- Make the voting duration alterable.
 CreateConVar("rcmv_debug", 0, {FCVAR_ARCHIVE, FCVAR_SERVER_CAN_EXECUTE }, "Enable debugging messages in console for RCMV. Recommended to keep disabled.")
-CreateConVar("rcmv_maxnominations", 4, {FCVAR_ARCHIVE, FCVAR_SERVER_CAN_EXECUTE }, "The maximum number of maps that can be nominated per round.")
-CreateConVar("rcmv_nominations", 1, {FCVAR_ARCHIVE, FCVAR_SERVER_CAN_EXECUTE }, "Allow players to nominate maps to play on.")
-CreateConVar("rcmv_numberofrandommaps", 3, {FCVAR_ARCHIVE, FCVAR_SERVER_CAN_EXECUTE }, "Number of maps to randomly select each time.")
+CreateConVar("rcmv_nomination_limit", 4, {FCVAR_ARCHIVE, FCVAR_SERVER_CAN_EXECUTE }, "The maximum number of maps that can be nominated per round.")
+CreateConVar("rcmv_nomination_enabled", 1, {FCVAR_ARCHIVE, FCVAR_SERVER_CAN_EXECUTE }, "Allow players to nominate maps to play on.")
+CreateConVar("rcmv_mapcount", 3, {FCVAR_ARCHIVE, FCVAR_SERVER_CAN_EXECUTE }, "Number of maps to randomly select each time.")
 CreateConVar("rcmv_nominate_ignore_playerlimit", 0, {FCVAR_ARCHIVE, FCVAR_SERVER_CAN_EXECUTE }, "Determine if nominations ignore map:player ratio restrictions.")
 concommand.Add("rcmv_forcevoting", forceVoting)
 

--- a/lua/autorun/server/sv_setup.lua
+++ b/lua/autorun/server/sv_setup.lua
@@ -7,6 +7,7 @@ CreateConVar("rcmv_debug", 0, {FCVAR_ARCHIVE, FCVAR_SERVER_CAN_EXECUTE }, "Enabl
 CreateConVar("rcmv_maxnominations", 4, {FCVAR_ARCHIVE, FCVAR_SERVER_CAN_EXECUTE }, "The maximum number of maps that can be nominated per round.")
 CreateConVar("rcmv_nominations", 1, {FCVAR_ARCHIVE, FCVAR_SERVER_CAN_EXECUTE }, "Allow players to nominate maps to play on.")
 CreateConVar("rcmv_numberofrandommaps", 3, {FCVAR_ARCHIVE, FCVAR_SERVER_CAN_EXECUTE }, "Number of maps to randomly select each time.")
+CreateConVar("rcmv_nominationsignoreplayercount", 0, {FCVAR_ARCHIVE, FCVAR_SERVER_CAN_EXECUTE }, "Determine if nominations ignore map:player ratio restrictions.")
 concommand.Add("rcmv_forcevoting", forceVoting)
 
 -- Check if anything exists, if not, create it

--- a/lua/autorun/server/sv_setup.lua
+++ b/lua/autorun/server/sv_setup.lua
@@ -7,7 +7,7 @@ CreateConVar("rcmv_debug", 0, {FCVAR_ARCHIVE, FCVAR_SERVER_CAN_EXECUTE }, "Enabl
 CreateConVar("rcmv_maxnominations", 4, {FCVAR_ARCHIVE, FCVAR_SERVER_CAN_EXECUTE }, "The maximum number of maps that can be nominated per round.")
 CreateConVar("rcmv_nominations", 1, {FCVAR_ARCHIVE, FCVAR_SERVER_CAN_EXECUTE }, "Allow players to nominate maps to play on.")
 CreateConVar("rcmv_numberofrandommaps", 3, {FCVAR_ARCHIVE, FCVAR_SERVER_CAN_EXECUTE }, "Number of maps to randomly select each time.")
-CreateConVar("rcmv_nominationsignoreplayercount", 0, {FCVAR_ARCHIVE, FCVAR_SERVER_CAN_EXECUTE }, "Determine if nominations ignore map:player ratio restrictions.")
+CreateConVar("rcmv_nominate_ignore_playerlimit", 0, {FCVAR_ARCHIVE, FCVAR_SERVER_CAN_EXECUTE }, "Determine if nominations ignore map:player ratio restrictions.")
 concommand.Add("rcmv_forcevoting", forceVoting)
 
 -- Check if anything exists, if not, create it

--- a/lua/autorun/server/sv_universal.lua
+++ b/lua/autorun/server/sv_universal.lua
@@ -22,11 +22,11 @@ function isWhitelistMode()
 end
 
 function getMaxNominations()
-    return GetConVar("rcmv_maxnominations"):GetInt()
+    return GetConVar("rcmv_nomination_limit"):GetInt()
 end
 
 function getNumberRandomMaps()
-    return GetConVar("rcmv_numberofrandommaps"):GetInt()
+    return GetConVar("rcmv_mapcount"):GetInt()
 end
 
 function getVotingDuration()
@@ -34,7 +34,7 @@ function getVotingDuration()
 end
 
 function nominationsAllowed()
-    if(GetConVar("rcmv_nominations"):GetInt() == 1) then
+    if(GetConVar("rcmv_nomination_enabled"):GetInt() == 1) then
         return true
     end
     return false

--- a/lua/autorun/server/sv_universal.lua
+++ b/lua/autorun/server/sv_universal.lua
@@ -81,11 +81,7 @@ end
 function getMapMinPlayers(map)
     for _,mapName in ipairs(mapData) do 
         if (mapName[1] == map) then
-            if not mapName[2] == nil and not mapName[2] == "" then
-                return mapName[2]
-            else
-                return 0
-            end
+            return tonumber(mapName[2]) or 0
         end
     end
     -- Map not found, tell the user and default to a safe number
@@ -95,15 +91,34 @@ end
 function getMapMaxPlayers(map)
     for _,mapName in ipairs(mapData) do 
         if (mapName[1] == map) then
-            if not mapName[3] == nil and not mapName[3] == "" then
-                return mapName[3]
-            else
-                return 999
-            end
+            return tonumber(mapName[3]) or 999
         end
     end
     ServerLog("RCMV:sv_universal.lua:getMapMaxPlayers(): Map " .. map .. " not found.")
     return 999
+end
+
+function playerMapRatioEnabled()
+    if(GetConVar("rcmv_nominationsignoreplayercount"):GetInt() == 0) then
+        return true
+    end
+    return false
+end
+
+function determineMapRatioLegal(map)
+    if playerMapRatioEnabled() then 
+        if player.GetCount() >= getMapMinPlayers(map) then
+            if player.GetCount() <= getMapMaxPlayers(map) then
+                dbg("enough players " .. map .. player.GetCount() .. " " .. getMapMinPlayers(map) .. " " .. getMapMaxPlayers(map))
+                return true
+            end
+            dbg("too many players for map")
+            return false, "there are too many players for this map"
+        end
+        dbg("not enough players for map")
+        return false, "there are not enough players for this map"
+    end
+    return true
 end
 
 function updateMaps()

--- a/lua/autorun/server/sv_universal.lua
+++ b/lua/autorun/server/sv_universal.lua
@@ -99,7 +99,7 @@ function getMapMaxPlayers(map)
 end
 
 function playerMapRatioEnabled()
-    if(GetConVar("rcmv_nominationsignoreplayercount"):GetInt() == 0) then
+    if(GetConVar("rcmv_nominate_ignore_playerlimit"):GetInt() == 0) then
         return true
     end
     return false

--- a/lua/autorun/server/sv_universal.lua
+++ b/lua/autorun/server/sv_universal.lua
@@ -133,6 +133,3 @@ function updateMaps()
         end
     end
 end
-
-print(getMapMinPlayers("ttt_terrortownexamplemap"))
-print(getMapMaxPlayers("ttt_terrortownexamplemap"))

--- a/lua/autorun/server/sv_universal.lua
+++ b/lua/autorun/server/sv_universal.lua
@@ -53,7 +53,7 @@ function insertScannedMaps()
 end
 
 function isBlackListed(map, localMapList)
-    for blacklistedMap in localMapList:gmatch("%S+") do 
+    for _,blacklistedMap in ipairs(localMapList) do 
         if (map == blacklistedMap) then
             return true
         end
@@ -61,12 +61,58 @@ function isBlackListed(map, localMapList)
     end 
 end
 
+function getMapData()
+    local localMapList = file.Read("rcmapvote/maplist.txt")
+    local processed = {}
+    local namesOnly = {}
+    
+    -- Split by newline, make array by delimiter " "
+    for map in localMapList:gmatch("([^\n]*)\n?") do
+        if (string.len(map) > 0) then -- may be a newline at end of file
+            table.insert(processed, string.Explode(" ",map))
+        end
+    end
+    for _,map in ipairs(processed) do
+            table.insert(namesOnly, map[1])
+    end
+    return processed,namesOnly
+end
+
+function getMapMinPlayers(map)
+    for _,mapName in ipairs(mapData) do 
+        if (mapName[1] == map) then
+            if not mapName[2] == nil and not mapName[2] == "" then
+                return mapName[2]
+            else
+                return 0
+            end
+        end
+    end
+    -- Map not found, tell the user and default to a safe number
+    ServerLog("RCMV:sv_universal.lua:getMapMaxPlayers(): Map " .. map .. " not found.")
+    return 0
+end
+function getMapMaxPlayers(map)
+    for _,mapName in ipairs(mapData) do 
+        if (mapName[1] == map) then
+            if not mapName[3] == nil and not mapName[3] == "" then
+                return mapName[3]
+            else
+                return 999
+            end
+        end
+    end
+    ServerLog("RCMV:sv_universal.lua:getMapMaxPlayers(): Map " .. map .. " not found.")
+    return 999
+end
+
 function updateMaps()
     dbg("updateMaps() has run")
     usableMaps = {} -- global, "update" is really a re-write from scratch
-    local localMapList = file.Read("rcmapvote/maplist.txt")
+    processed,localMapList = getMapData()
+    mapData = processed;
     if isWhitelistMode() then
-        for map in localMapList:gmatch("%S+") do 
+        for _,map in ipairs(localMapList) do 
             table.insert(usableMaps, map) 
         end
     else
@@ -87,3 +133,6 @@ function updateMaps()
         end
     end
 end
+
+print(getMapMinPlayers("ttt_terrortownexamplemap"))
+print(getMapMaxPlayers("ttt_terrortownexamplemap"))


### PR DESCRIPTION
Allow maps to be 'disabled' if there aren't enough players on the server, or if there are too many players on the server. Format for maps goes "mapname min max" in the `maplist.txt` file. An example is as follows:
`ttt_rooftops_2016_v2 15 30`
If omitted, defaults to 0 and 999 respectively.